### PR TITLE
fix: add -f flag to rm in clean target (#10)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,5 @@ build:
 	v . -o vas
 
 clean:
-	rm *.o *.out ./vas examples/*.o
+	rm -f *.o *.out ./vas examples/*.o
 


### PR DESCRIPTION
Closes #10

## What changed

Added `-f` (force) flag to the `rm` command in the `clean` Makefile target:

```diff
-	rm *.o *.out ./vas examples/*.o
+	rm -f *.o *.out ./vas examples/*.o
```

## Why

Without `-f`, `make clean` fails with exit code 1 on a fresh checkout because the glob patterns (`*.o`, `*.out`, etc.) don't match any files. The `-f` flag suppresses "no such file or directory" errors, which is the standard fix for this pattern.

## Test result

Verified `make clean` exits 0 on a fresh checkout with no built artifacts. The V compiler was not available in the CI environment, so a full build could not be run — but the one-line change is straightforward and risk-free.

🤖 AI-generated — review before merging.