### PR TITLE
ci: pin action versions to commit SHAs and add Dependabot (#12)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci-elf.yml
+++ b/.github/workflows/ci-elf.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
       - name: Install V
-        uses: vlang/setup-v@v1
+        uses: vlang/setup-v@2c790c60223ed135f6949d1358675e4fd004b801  # v1
         with:
           check-latest: true
 
       - name: Checkout ${{ github.event.repository.name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Build vas
         run: v .

--- a/.github/workflows/ci-macho.yml
+++ b/.github/workflows/ci-macho.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
       - name: Install V
-        uses: vlang/setup-v@v1
+        uses: vlang/setup-v@2c790c60223ed135f6949d1358675e4fd004b801  # v1
         with:
           check-latest: true
 
       - name: Checkout ${{ github.event.repository.name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Build vas
         run: v .

--- a/.github/workflows/ci-pe.yml
+++ b/.github/workflows/ci-pe.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
       - name: Install V
-        uses: vlang/setup-v@v1
+        uses: vlang/setup-v@2c790c60223ed135f6949d1358675e4fd004b801  # v1
         with:
           check-latest: true
 
       - name: Checkout ${{ github.event.repository.name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install MinGW cross-compiler
         run: sudo apt-get install -y mingw-w64


### PR DESCRIPTION
Closes #12

## What changed

- **`.github/workflows/ci-elf.yml`**, **`ci-macho.yml`**, **`ci-pe.yml`**: replaced floating mutable tags with full 40-character commit SHAs (tag kept as an inline comment for readability):
  - `vlang/setup-v@v1` → `vlang/setup-v@2c790c60223ed135f6949d1358675e4fd004b801  # v1`
  - `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4`
- **`.github/dependabot.yml`**: added Dependabot `github-actions` ecosystem config (monthly schedule) so SHA pins are kept up to date automatically.

## Why

Mutable tags (e.g. `v4`) can be silently moved to a different commit by the action's maintainer or a compromised account. SHA-pinning ensures the exact code that was tested is always used, even if the tag is later moved.

## Test / build result

This is a CI-config-only change; no V source files were modified. The changed workflow files are syntactically valid YAML. No pre-existing test suite failures introduced.

🤖 AI-generated — review before merging.