### PR TITLE
docs: add CONTRIBUTING.md and link from README (#13)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to vas
+
+Thank you for your interest in contributing! This guide covers everything you need to build, test, and submit patches.
+
+## Prerequisites
+
+- [V compiler](https://vlang.io) — `v` must be on your `PATH`
+- `gcc` and `ld` — needed by the test suite and the examples
+- Alternatively, use the [Docker setup](README.md#docker-setup) which ships all of the above
+
+## Build
+
+```sh
+v . -o vas
+# or
+make build
+```
+
+## Run the tests
+
+```sh
+v test tests/
+# or
+make test
+```
+
+The runner rebuilds `vas`, assembles every case in `tests/cases/{elf,macho,pe}/`, and asserts that the output bytes match the recorded MD5 checksums.
+
+## Add a test case
+
+Each test case is a pair of files: an assembly source (`<name>.s`) and its expected MD5 (`<name>.expected.md5`).
+
+```sh
+# ELF example
+$EDITOR tests/cases/elf/my_feature.s
+./vas -f elf tests/cases/elf/my_feature.s
+md5sum tests/cases/elf/my_feature.o | awk '{print $1}' > tests/cases/elf/my_feature.expected.md5
+rm tests/cases/elf/my_feature.o
+v test tests/
+```
+
+Replace `elf` with `macho` or `pe` for other output formats. On macOS use `md5 -q` instead of `md5sum … | awk`.
+
+## Modify the instruction table
+
+The assembler's instruction set is data-driven. Rows are generated from
+`third_party/insns.dat` (bundled from [NASM](https://www.nasm.us/)) and committed to
+`encoder/insns_table.gen.v`.
+
+After editing `third_party/insns.dat` or the parser in `tools/gen_insns.v`, regenerate
+the table and commit the result:
+
+```sh
+v run tools/gen_insns.v
+git add encoder/insns_table.gen.v
+```
+
+See [LICENSE-NASM](LICENSE-NASM) for the BSD-2-clause notice covering `insns.dat` and
+any code derived from it.
+
+## CI checklist
+
+Every pull request must pass all three CI workflows:
+
+| Workflow | Badge |
+|----------|-------|
+| ELF CI   | [![ELF CI](https://github.com/v420v/vas/actions/workflows/ci-elf.yml/badge.svg)](https://github.com/v420v/vas/actions/workflows/ci-elf.yml) |
+| Mach-O CI | [![Mach-O CI](https://github.com/v420v/vas/actions/workflows/ci-macho.yml/badge.svg)](https://github.com/v420v/vas/actions/workflows/ci-macho.yml) |
+| PE CI    | [![PE CI](https://github.com/v420v/vas/actions/workflows/ci-pe.yml/badge.svg)](https://github.com/v420v/vas/actions/workflows/ci-pe.yml) |
+
+Run `v test tests/` locally before pushing to catch regressions early.
+
+## Code of Conduct
+
+Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ ELF / Mach-O / PE programs.
 
 ## Testing
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide on building, running tests, adding test cases, and regenerating the instruction table.
+
 Regression tests live under `tests/cases/`, split by output format:
 
 ```


### PR DESCRIPTION
Closes #13

## What changed and why

- Added `CONTRIBUTING.md` at the repository root covering all seven areas from the issue:
  1. Prerequisites (V compiler, gcc, ld)
  2. Build (`v . -o vas` / `make build`)
  3. Run tests (`v test tests/` / `make test`)
  4. Add a test case — three-step workflow for ELF/Mach-O/PE
  5. Modify the instruction table — edit `third_party/insns.dat` → run `v run tools/gen_insns.v` → commit the generated file
  6. CI checklist — table with badges for all three workflows (ELF, Mach-O, PE)
  7. Pointer to `CODE_OF_CONDUCT.md`

- Updated `README.md` Testing section to link to `CONTRIBUTING.md`, satisfying the acceptance criterion that `README.md` link to the contributing guide from its Testing section.

GitHub will now surface the "Please read CONTRIBUTING.md" banner on new issues and PRs.

## Test / build result

This is a documentation-only change (two Markdown files). No code was modified; no build or test failures introduced. The repo's existing CI (`v test tests/`) is unchanged.

---

🤖 AI-generated — review before merging.