### PR TITLE
ci: add v vet step to all three CI workflows (#16)

### DIFF
--- a/.github/workflows/ci-elf.yml
+++ b/.github/workflows/ci-elf.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Build vas
         run: v .
 
+      - name: Vet
+        run: v vet .
+
       - name: Smoke test (assemble + link + run)
         run: |
           ./vas main.s -o main.o

--- a/.github/workflows/ci-macho.yml
+++ b/.github/workflows/ci-macho.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Build vas
         run: v .
 
+      - name: Vet
+        run: v vet .
+
       - name: Smoke test (assemble + link + run)
         run: |
           ./vas -f macho examples/macos/hello.s

--- a/.github/workflows/ci-pe.yml
+++ b/.github/workflows/ci-pe.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Build vas
         run: v .
 
+      - name: Vet
+        run: v vet .
+
       - name: Smoke test (assemble + cross-link)
         run: |
           ./vas -f pe examples/windows/hello.s


### PR DESCRIPTION
Closes #16

## What changed and why

Added a `Vet` step running `v vet .` immediately after the `Build vas` step in all three CI workflows:

- `.github/workflows/ci-elf.yml`
- `.github/workflows/ci-macho.yml`
- `.github/workflows/ci-pe.yml`

`v vet` is the V toolchain's built-in static analyser — zero-config, no extra dependencies, and it catches classes of bugs (unused variables, wrong-arity format strings, shadowed names) that neither compilation nor regression tests catch. Running it in all three workflows ensures every PR is vetted regardless of which output format the change touches.

## Test / build result

The change is purely to CI configuration files; no V source was modified. The vet step will run on the next CI trigger. The generated file `encoder/insns_table.gen.v` carries an `// AUTO-GENERATED` header comment but does not use `@[generated]`; if `v vet` surfaces false positives there a follow-up can add the attribute.

## Files changed

- `.github/workflows/ci-elf.yml` — added Vet step
- `.github/workflows/ci-macho.yml` — added Vet step
- `.github/workflows/ci-pe.yml` — added Vet step

🤖 AI-generated — review before merging.