### PR TITLE
fix: Makefile build target now uses -prod flag (#17)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 
 build:
-	v . -o vas
+	v . -prod -o vas
+
+debug:
+	v . -cg -o vas
 
 clean:
 	rm -f *.o *.out ./vas examples/*.o

--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ docker run --rm -it -v "${pwd}:/root/env" vas
 Requires the V compiler to be installed.
 
 ```sh
-v . -prod
+make
 ```
+
+This runs `v . -prod -o vas`, producing an optimised release binary. For a
+debug build (with debug symbols, no optimisations) use `make debug`.
 
 ## Usage
 


### PR DESCRIPTION
Closes #17

## What changed and why

- **`Makefile`**: The `build` target now runs `v . -prod -o vas` instead of `v . -o vas`, matching the README's documented build command and ensuring `make` / `make build` produces an optimised release binary.
- **`Makefile`**: Added an explicit `debug` target (`v . -cg -o vas`) so developers can intentionally build with debug symbols without having to remember the flag.
- **`README.md`**: Updated the Build section to show `make` as the canonical install command (which invokes `v . -prod -o vas` internally), with a brief note about `make debug` for development builds.

## Test / build result

The V compiler is not available in the CI environment where this PR was prepared, so a local build could not be run. The changes are limited to build configuration (`Makefile`) and documentation (`README.md`) — no assembler logic was modified. The existing CI workflows (ELF, Mach-O, PE) will validate the build on push.

🤖 AI-generated — review before merging.