### PR TITLE
lexer: fix \xNN hex escapes in read_escaped_char (#18)

### DIFF
--- a/lexer/lexer.v
+++ b/lexer/lexer.v
@@ -203,11 +203,15 @@ fn (mut l Lexer) read_escaped_char() u8 {
 			eprintln('error: invalid hex escape sequence');
 			exit(1)
 		}
-
-		for is_hex_digit(l.c) {
-			c = (c << 4) + from_hex(l.c)
+		// Mirror the octal branch: leave l.c on the last digit consumed so
+		// the caller's l.advance() steps past it correctly.  Cap at two hex
+		// digits to match GAS byte semantics.
+		c = from_hex(l.c)
+		if is_hex_digit(l.peak(1)) {
 			l.advance()
+			c = (c << 4) + from_hex(l.c)
 		}
+		return c
 	}
 
 	if l.c == `a` {

--- a/tests/cases/elf/hex_escape.expected.md5
+++ b/tests/cases/elf/hex_escape.expected.md5
@@ -1,0 +1,1 @@
+0fe40c7ff4d5980619fbb9b1cd4aca95

--- a/tests/cases/elf/hex_escape.s
+++ b/tests/cases/elf/hex_escape.s
@@ -1,0 +1,6 @@
+.section .rodata
+# \xNN hex escapes in .ascii / .asciz / .string directives
+hex_bytes:  .ascii "\x41\x42\x43"      # A B C
+hex_nul:    .asciz "\x48\x65\x6c\x6c\x6f"  # Hello\0
+hex_str:    .string "\x77\x6f\x72\x6c\x64"  # world\0
+hex_upper:  .ascii "\x4F\x4B"          # OK  (upper-case hex digits)


### PR DESCRIPTION
Closes #18

## What changed

`read_escaped_char()` in `lexer/lexer.v` had two related bugs in the `\xNN` hex escape branch:

1. **Missing `return c`** — after consuming hex digits, the function fell through to the named-escape checks (`\a`, `\b`, `\n`, …) and finally returned `l.c` (the character *after* the hex sequence), discarding the decoded byte value entirely.

2. **Loop advanced past the last hex digit** — the consume loop called `l.advance()` after reading each digit, so when it exited `l.c` was already pointing at the first non-hex character. `read_string()` then called `l.advance()` again, skipping that character. This violated the contract of `read_escaped_char()`: leave `l.c` on the *last* character of the escape so the caller's `l.advance()` can step cleanly past it (same invariant as the octal and named-escape branches).

**Fix**: mirror the octal branch — use `l.peak(1)` to look ahead and only advance when another hex digit follows, then `return c`. This keeps `l.c` on the last hex digit consumed. Also caps hex escapes at two digits (matching GAS byte semantics for assembly strings).

## Files changed

| File | Change |
|------|--------|
| `lexer/lexer.v` | Fix hex escape branch in `read_escaped_char()` |
| `tests/cases/elf/hex_escape.s` | New regression test exercising `\xNN` in `.ascii`, `.asciz`, `.string` |
| `tests/cases/elf/hex_escape.expected.md5` | Expected MD5 for the regression test |

## Test / build result

```
v test tests/elf_test.v
---- Testing... ----------------------------------------------------------------
--------------------------------------------------------------------------------
Summary for all V _test.v files: 1 passed, 1 total.
```

All existing ELF tests still pass; the new `hex_escape` case now passes as well.

Example verification — `.ascii "\x41\x42\x43"` now emits bytes `41 42 43` (previously: wrong bytes + broken string termination).

🤖 AI-generated — review before merging.