### PR TITLE
lexer: guard against unterminated string literal OOB panic (#19)

### DIFF
--- a/error/error.v
+++ b/error/error.v
@@ -3,7 +3,6 @@ module error
 import token
 
 pub fn print(pos token.Position, msg string) {
-	err := '\u001b[1m$pos.file_name:$pos.line: \x1b[91merror\x1b[0m\u001b[1m: $msg \033[0m'
+	err := '\u001b[1m${pos.file_name}:${pos.line}: \x1b[91merror\x1b[0m\u001b[1m: ${msg} \033[0m'
 	eprintln(err)
 }
-

--- a/lexer/lexer.v
+++ b/lexer/lexer.v
@@ -239,14 +239,21 @@ fn (mut l Lexer) read_string() token.Token {
 	pos := l.current_pos()
 	l.advance()
 	mut lit := []u8{}
-	for l.c != `"` {
+	for l.c != `"` && l.c != `\0` {
 		if l.c == `\\` {
 			lit << l.read_escaped_char()
+			if l.c == `\0` {
+				break
+			}
 			l.advance()
 		} else {
 			lit << l.c
 			l.advance()
 		}
+	}
+	if l.c == `\0` {
+		error.print(pos, 'unterminated string literal')
+		exit(1)
 	}
 	l.advance()
 	return token.Token{


### PR DESCRIPTION
Closes #19

## What changed and why

`read_string()` in `lexer/lexer.v` had no EOF guard in its loop, so an unterminated string literal (no closing `"` before end of input) would spin past the end of the input buffer and trigger a V `array index out of range` panic.

Two-part fix in `read_string()`:
1. **Loop condition**: changed `for l.c != '"'` → `for l.c != '"' && l.c != '\0'` so the loop exits at EOF instead of continuing.
2. **Post-loop EOF check + backslash-at-EOF guard**: after calling `read_escaped_char()`, check `if l.c == '\0' { break }` before calling `l.advance()` — this prevents a second OOB when a backslash is the very last byte (after `read_escaped_char` advances past `\`, `l.c` is already `\0`, and calling `advance()` again would increment `idx` past `text.len`).
3. **Clean error**: after the loop, if `l.c == '\0'`, call `error.print(pos, 'unterminated string literal')` and `exit(1)` instead of silently falling through.

## Test / build result

- `v . -o vas`: **BUILD SUCCESS** (only pre-existing notices, no errors)
- `v test tests/`: **4 passed, 4 total** — all existing tests pass
- Manual repro from the issue (`printf '.text\n.ascii "no closing quote\n'`) now exits non-zero with an error message instead of panicking.

🤖 AI-generated — review before merging.