### PR TITLE
encoder: validate align_directive to prevent shift overflow and silent drops (#25)

### DIFF
--- a/encoder/directive.v
+++ b/encoder/directive.v
@@ -99,6 +99,25 @@ fn (mut e Encoder) fill() {
 fn (mut e Encoder) align_directive(is_p2 bool) {
 	pos := e.tok.pos
 	first := eval_expr(e.parse_expr())
+
+	if is_p2 {
+		// 1 << 31 overflows to a negative int; GNU as caps the exponent at 30.
+		if first < 0 || first > 30 {
+			error.print(pos, '.p2align exponent must be in the range 0..30 (got ${first})')
+			exit(1)
+		}
+	} else {
+		if first < 0 {
+			error.print(pos, 'alignment must be a positive value (got ${first})')
+			exit(1)
+		}
+		// Alignment of 0 or 1 is a no-op; anything else must be a power of two.
+		if first > 1 && (first & (first - 1)) != 0 {
+			error.print(pos, 'alignment ${first} is not a power of two')
+			exit(1)
+		}
+	}
+
 	align_bytes := if is_p2 { 1 << u32(first) } else { first }
 
 	mut fill := -1


### PR DESCRIPTION
Closes #25

## What changed and why

`align_directive()` in `encoder/directive.v` had two bugs:

1. **32-bit shift overflow** — `.p2align 31` computed `1 << u32(31)` which
   evaluates to `-2147483648` (negative `int`) in V's 32-bit arithmetic.
   `.p2align 32` (or higher) is full undefined/wrap-around behavior.

2. **Silent no-op on invalid input** — the subsequent `if align_bytes <= 1`
   guard silently dropped the directive rather than surfacing the error
   to the user.

The fix adds input validation before computing `align_bytes`:

- **p2 form** (`.p2align`): validate `0 <= exponent <= 30` and call
  `error.print` + `exit(1)` for anything out of range. This matches GNU `as`
  behavior (capped at 30 to keep the result a positive 32-bit int).
- **byte-count forms** (`.align` / `.balign`): reject negative values and
  non-power-of-two values with a clear diagnostic. Zero and 1 remain valid
  no-ops.

## Test / build result

- Project builds cleanly with `v .` (only pre-existing notices, no new warnings).
- All existing ELF regression tests pass (`v test tests/elf_test.v`: 1 passed, 1 total).
- Smoke tests confirm the new error paths fire correctly:
  - `.p2align 31` → error "exponent must be in the range 0..30 (got 31)"
  - `.p2align 40` → error "exponent must be in the range 0..30 (got 40)"
  - `.balign -4`  → error "alignment must be a positive value (got -4)"
  - `.balign 7`   → error "alignment 7 is not a power of two"
  - `.p2align 4` / `.p2align 30` → assemble successfully

🤖 AI-generated — review before merging.