### PR TITLE
fix: snapshot number token position before advancing in parse_factor (#26)

### DIFF
--- a/encoder/encoder.v
+++ b/encoder/encoder.v
@@ -403,10 +403,11 @@ fn (mut e Encoder) parse_register() Expr {
 fn (mut e Encoder) parse_factor() Expr {
 	match e.tok.kind {
 		.number {
+			pos := e.tok.pos
 			lit := e.tok.lit
 			e.next()
 			return Number{
-				pos: e.tok.pos
+				pos: pos
 				lit: lit
 			}
 		}


### PR DESCRIPTION
Closes #26

## What changed

In `parse_factor()` in `encoder/encoder.v`, the `.number` match arm was calling `e.next()` before capturing `e.tok.pos`, so the `Number` node received the source position of the **token after** the numeric literal instead of the literal itself.

The fix snapshots `pos := e.tok.pos` before `e.next()`, exactly mirroring the adjacent `.ident` arm which already does this correctly.

```diff
 		.number {
+			pos := e.tok.pos
 			lit := e.tok.lit
 			e.next()
 			return Number{
-				pos: e.tok.pos
+				pos: pos
 				lit: lit
 			}
 		}
```

## Why

Any diagnostic that uses a numeric literal's position (invalid-number errors, division-by-zero in expression evaluation, etc.) was pointing at the wrong column — often the next token, sometimes the next source line. This degraded the quality of error messages.

## Test / build result

The V compiler (`v`) is not available in the CI environment used for this automated fix, so a full build could not be run. The change is a one-line mechanical fix with clear precedent from the `.ident` arm in the same function.

🤖 AI-generated — review before merging.