### PR TITLE
encoder: add division-by-zero guard in eval_expr_get_symbol_64 (#39)

### DIFF
--- a/.github/workflows/ci-elf.yml
+++ b/.github/workflows/ci-elf.yml
@@ -34,6 +34,9 @@ jobs:
       - name: ELF regression suite
         run: v test tests/elf_test.v
 
+      - name: Error regression suite
+        run: v test tests/error_test.v
+
       - name: Verify generator output is committed
         run: |
           v run tools/gen_insns.v

--- a/encoder/encoder.v
+++ b/encoder/encoder.v
@@ -660,8 +660,12 @@ fn eval_expr_get_symbol_64(expr Expr, mut arr []string) i64 {
 						arr)
 				}
 				.div {
-					eval_expr_get_symbol_64(expr.left_hs, mut arr) / eval_expr_get_symbol_64(expr.right_hs, mut
-						arr)
+					r := eval_expr_get_symbol_64(expr.right_hs, mut arr)
+					if r == 0 {
+						error.print(expr.pos, 'division by zero')
+						exit(1)
+					}
+					eval_expr_get_symbol_64(expr.left_hs, mut arr) / r
 				}
 				else {
 					panic('not implemented yet')

--- a/tests/cases/errors/div_by_zero.s
+++ b/tests/cases/errors/div_by_zero.s
@@ -1,0 +1,2 @@
+.section .data
+.zero 1/0

--- a/tests/error_test.v
+++ b/tests/error_test.v
@@ -1,0 +1,19 @@
+module main
+
+import os
+
+const errors_dir = os.join_path(project_root, 'tests', 'cases', 'errors')
+
+fn testsuite_begin() {
+	ensure_vas_built() or {
+		assert false, '${err}'
+	}
+}
+
+fn test_div_by_zero_clean_error() {
+	s_path := os.join_path(errors_dir, 'div_by_zero.s')
+	result := os.execute('${vas_bin} -f elf ${s_path}')
+	assert result.exit_code != 0, 'expected non-zero exit for division by zero, got 0'
+	assert !result.output.contains('panic'), 'expected clean error, got panic: ${result.output}'
+	assert result.output.contains('division by zero'), 'expected "division by zero" in error output, got: ${result.output}'
+}


### PR DESCRIPTION
Closes #39

## What changed

In `encoder/encoder.v`, the `.div` arm of `eval_expr_get_symbol_64` (around line 662) had no check for a zero divisor. This caused the V runtime to panic with an "integer division by zero" stack trace instead of emitting a clean, positioned assembler diagnostic.

The fix mirrors the pattern already used in `eval_reloc_expr` (line 738): evaluate the right-hand side first, and if it is `0`, call `error.print(expr.pos, 'division by zero')` followed by `exit(1)`.

## Files changed

- `encoder/encoder.v` — added zero-divisor guard in `eval_expr_get_symbol_64`
- `tests/cases/errors/div_by_zero.s` — minimal repro assembly file (`.zero 1/0`)
- `tests/error_test.v` — regression test verifying non-zero exit and clean error message

## Test / build result

- `v . -prod -o vas` — builds cleanly (only pre-existing `notice` about sign shift, not new)
- `v test tests/elf_test.v` — all 43 existing ELF cases pass
- `v test tests/error_test.v` — new regression test passes; confirms `.zero 1/0` produces `error: division by zero` at the correct source position with exit code 1, no panic

🤖 AI-generated — review before merging.