### PR TITLE
macho: fix .bss.<name> subsections emitting file data as zerofill (#44)

### DIFF
--- a/macho/macho.v
+++ b/macho/macho.v
@@ -153,7 +153,7 @@ pub fn new(out_file string, keep_locals bool, rela_text_users []encoder.Rela, us
 	mut idx := 1
 	for name, section in user_defined_sections {
 		sectname, segname := elf_section_to_macho(name, section.flags)
-		is_zerofill := name == '.bss'
+		is_zerofill := name == '.bss' || name.starts_with('.bss.')
 		m.sections << MachoSection{
 			elf_name:    name
 			sectname:    sectname
@@ -222,7 +222,7 @@ fn section_type_flags(name string, elf_flags int) u32 {
 
 fn section_align_pow(name string, _ int) u32 {
 	if name == '.text' || name.starts_with('.text.') { return 2 } // 4-byte
-	if name == '.data' || name == '.bss' { return 3 } // 8-byte
+	if name == '.data' || name == '.bss' || name.starts_with('.bss.') { return 3 } // 8-byte
 	return 0
 }
 


### PR DESCRIPTION
Closes #44

## What changed and why

`macho/macho.v` had two exact-match checks for `.bss` that were inconsistent with the rest of the module:

1. **`is_zerofill` (line 156):** was `name == '.bss'` — now `name == '.bss' || name.starts_with('.bss.')`.
2. **`section_align_pow` (line 225):** was `name == '.bss'` — now `name == '.bss' || name.starts_with('.bss.')`.

Both `elf_section_to_macho` and `section_type_flags` already used the broader `starts_with('.bss.')` pattern. The mismatch meant that a `.bss.foo` subsection received `S_ZEROFILL` flags (correct) but `is_zerofill=false` (wrong), so the section was given real file bytes and a nonzero file offset — producing a malformed Mach-O object that the linker rejects.

## Test/build result

The V language toolchain (`v`) is not available in the CI runner environment used to generate this PR, so the test suite (`v test tests/`) could not be executed locally. The fix is a two-line mechanical extension of the existing `.bss.` pattern already present in the same file.

🤖 AI-generated — review before merging.