### PR TITLE
pe: error on r_x86_64_16/8 and r_x86_64_pc64 instead of emitting wrong-width COFF reloc (#45)

### DIFF
--- a/pe/pe.v
+++ b/pe/pe.v
@@ -163,11 +163,26 @@ fn section_characteristics(name string, elf_flags int) u32 {
 }
 
 // Maps ELF relocation types to COFF AMD64 relocation types.
+// Aborts with a clear diagnostic for ELF relocation widths that have no COFF
+// equivalent rather than silently emitting a wider relocation that would
+// overwrite adjacent bytes (e.g. r_x86_64_16 / r_x86_64_8 → ADDR32 was wrong).
 fn elf_rtype_to_coff(rtype u64) u16 {
 	match rtype {
-		r_x86_64_64                                          { return image_rel_amd64_addr64 }
-		r_x86_64_32, r_x86_64_32s, r_x86_64_16, r_x86_64_8 { return image_rel_amd64_addr32 }
-		else                                                  { return image_rel_amd64_rel32 }
+		r_x86_64_64               { return image_rel_amd64_addr64 }
+		r_x86_64_32, r_x86_64_32s { return image_rel_amd64_addr32 }
+		r_x86_64_16 {
+			eprintln('pe: error: R_X86_64_16 has no COFF/AMD64 equivalent — `.word sym` is unsupported for PE output')
+			exit(1)
+		}
+		r_x86_64_8 {
+			eprintln('pe: error: R_X86_64_8 has no COFF/AMD64 equivalent — `.byte sym` is unsupported for PE output')
+			exit(1)
+		}
+		r_x86_64_pc64 {
+			eprintln('pe: error: R_X86_64_PC64 has no COFF/AMD64 equivalent — 64-bit PC-relative relocation is unsupported for PE output')
+			exit(1)
+		}
+		else { return image_rel_amd64_rel32 }
 	}
 }
 


### PR DESCRIPTION
Closes #45

## What changed and why

`elf_rtype_to_coff` in `pe/pe.v` previously silently mapped `R_X86_64_16` and `R_X86_64_8` to the 4-byte `IMAGE_REL_AMD64_ADDR32` relocation type, and `build_relocations` would then call `embed_i32` to write a 4-byte inline addend into a 2- or 1-byte data slot — corrupting the adjacent 2–3 bytes. COFF/AMD64 has no native 16- or 8-bit absolute relocation type, so there is no correct fix short of erroring.

This PR replaces the silent wrong-width mapping with a clear diagnostic and `exit(1)` for:
- `R_X86_64_16` (`.word sym` — 2-byte slot, no COFF equivalent)
- `R_X86_64_8` (`.byte sym` — 1-byte slot, no COFF equivalent)  
- `R_X86_64_PC64` (64-bit PC-relative — no COFF/AMD64 equivalent; previously fell through to `REL32`, a 4-byte type)

32-bit (`R_X86_64_32`/`R_X86_64_32S` → `ADDR32`) and 64-bit (`R_X86_64_64` → `ADDR64`) relocations are unchanged.

## Test / build result

Built with V 0.5.1. Build succeeded (one pre-existing notice about signed shift, unrelated to this change).

Manual functional tests:
- `.word sym` with `-f pe` → exits 1 with `pe: error: R_X86_64_16 has no COFF/AMD64 equivalent — .word sym is unsupported for PE output` ✓
- `.byte sym` with `-f pe` → exits 1 with `pe: error: R_X86_64_8 has no COFF/AMD64 equivalent — .byte sym is unsupported for PE output` ✓
- `.long sym` / `.quad sym` with `-f pe` → exits 0, object file produced ✓

🤖 AI-generated — review before merging.