### PR TITLE
fix parse_factor: capture Neg position before consuming '-' (#46)

### DIFF
--- a/encoder/encoder.v
+++ b/encoder/encoder.v
@@ -433,10 +433,11 @@ fn (mut e Encoder) parse_factor() Expr {
 			return e.split_minus_ident(lit, ident_pos)
 		}
 		.minus {
+			pos := e.tok.pos
 			e.next()
 			expr := e.parse_factor()
 			return Neg{
-				pos: e.tok.pos
+				pos: pos
 				expr: expr
 			}
 		}


### PR DESCRIPTION
Closes #46

## What changed and why

In `encoder/encoder.v`, the `.minus` arm of `parse_factor` was recording the position of the token **after** the negated expression on the `Neg` node, because `e.tok.pos` was read after `e.next()` and `e.parse_factor()` had both advanced the lexer past the operand.

The fix captures `e.tok.pos` into a local variable `pos` **before** calling `e.next()`, then uses that saved position in the `Neg` struct. This ensures diagnostics anchored on a `Neg` node point at the `-` character, not at whatever token follows the negated expression.

## Change

```diff
 .minus {
+    pos := e.tok.pos
     e.next()
     expr := e.parse_factor()
     return Neg{
-        pos: e.tok.pos
+        pos: pos
         expr: expr
     }
 }
```

## Test / build result

- **Build:** `v . -prod -o vas` — succeeded (3 notices, no errors; all pre-existing)
- **Tests:** `v test tests/` — **4 passed, 4 total**

🤖 AI-generated — review before merging.