### PR TITLE
fix eval_expr i64→int truncation in .zero/.skip/.space/.fill (#47)

### DIFF
--- a/encoder/directive.v
+++ b/encoder/directive.v
@@ -35,7 +35,7 @@ fn (mut e Encoder) zero() {
 	// an absolute-memory reference.
 	operand := e.parse_expr()
 
-	n := eval_expr(operand)
+	n := eval_count(operand)
 
 	for _ in 0..n {
 		e.current_instr.code << 0
@@ -48,7 +48,7 @@ fn (mut e Encoder) zero() {
 fn (mut e Encoder) skip() {
 	e.set_current_instr(.zero)
 
-	n := eval_expr(e.parse_expr())
+	n := eval_count(e.parse_expr())
 	mut fill := u8(0)
 	if e.tok.kind == .comma {
 		e.next()
@@ -65,12 +65,12 @@ fn (mut e Encoder) skip() {
 fn (mut e Encoder) fill() {
 	e.set_current_instr(.zero)
 
-	repeat := eval_expr(e.parse_expr())
+	repeat := eval_count(e.parse_expr())
 	mut size := 1
 	mut value := i64(0)
 	if e.tok.kind == .comma {
 		e.next()
-		size = eval_expr(e.parse_expr())
+		size = eval_count(e.parse_expr())
 		if e.tok.kind == .comma {
 			e.next()
 			mut used := []string{}

--- a/encoder/encoder.v
+++ b/encoder/encoder.v
@@ -689,6 +689,26 @@ fn eval_expr(expr Expr) int {
 	return int(eval_expr_get_symbol_64(expr, mut empty))
 }
 
+// eval_count evaluates a reservation-count expression and validates the result.
+// Unlike eval_expr it calls eval_expr_get_symbol_64 directly and rejects values
+// that would be silently truncated: negative (would flip sign) or > 2^31-1
+// (would wrap to zero or a smaller value in an int cast). Used by .zero / .skip
+// / .space / .fill so that oversized or malformed counts produce a clear error
+// instead of silently emitting wrong byte counts.
+fn eval_count(expr Expr) int {
+	mut empty := []string{}
+	val := eval_expr_get_symbol_64(expr, mut empty)
+	if val < 0 {
+		error.print(e_pos(expr), 'count must not be negative (got ${val})')
+		exit(1)
+	}
+	if val > 0x7fff_ffff {
+		error.print(e_pos(expr), 'count ${val} exceeds 2147483647; too large to reserve in a single object file')
+		exit(1)
+	}
+	return int(val)
+}
+
 // eval_reloc_expr evaluates a data expression into a constant plus a list of
 // symbol terms with signed coefficients (+1 for `sym`, -1 for `-sym`). `sign`
 // is inherited from any enclosing subtraction/negation; start the walk with


### PR DESCRIPTION
Closes #47

## What changed and why

`eval_expr` in `encoder/encoder.v` casted its `i64` result directly to V's 32-bit `int`, silently truncating the count arguments for `.zero`, `.skip`/`.space`, and `.fill`. For example:

- `.skip 0x80000000` — the `int` cast produces a negative value; the `for _ in 0..n` loop iterates zero times → 0 bytes emitted instead of 2 GiB.
- `.skip 0x100000000` — wraps to 0 → 0 bytes emitted silently.

**Fix:** Add `eval_count(expr Expr) int` in `encoder/encoder.v` that calls `eval_expr_get_symbol_64` directly and validates before casting:
- Negative result → `error.print` + `exit(1)` with the actual value.
- Result > 2147483647 (2^31-1) → `error.print` + `exit(1)` with the actual value and limit.

Use `eval_count` instead of `eval_expr` for the count/repeat/size arguments in `zero()`, `skip()`, and `fill()` in `encoder/directive.v`.

## Files changed

- `encoder/encoder.v` — new `eval_count` helper (20 lines)
- `encoder/directive.v` — 4 call sites updated to use `eval_count`

## Test / build result

```
v test tests/  →  4 passed, 4 total
```

Smoke tests:
```
.skip -1           → error: count must not be negative (got -1)
.skip 0x100000000  → error: count 4294967296 exceeds 2147483647; too large to reserve in a single object file
.skip 4            → success (0 exit)
```

🤖 AI-generated — review before merging.